### PR TITLE
Update package.json to not include engine and npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,6 @@
     "backbone",
     "events"
   ],
-  "engines": {
-    "node": "0.8.x",
-    "npm": "1.2.x"
-  },
   "dependencies": {},
   "devDependencies": {
     "mocha": "1.8.x",


### PR DESCRIPTION
npm is printing warnings when installing this now in node 10.x.0. 

Given the simplicity of this module, these restrictions seem a bit unnecessary perhaps? Curious of your thoughts. It'd be great if you would consider making them more lenient at least. 

Thanks for extracting this module, very useful!
